### PR TITLE
V0.1.1 rfc enforce

### DIFF
--- a/laviewset/__init__.py
+++ b/laviewset/__init__.py
@@ -2,11 +2,13 @@ from typing import Tuple
 
 from .routes import Route
 from .views import ViewSet, HttpMethods
+from .resources import rfc
 
 __all__: Tuple[str] = (
     'Route',
     'ViewSet',
-    'HttpMethods'
+    'HttpMethods',
+    'rfc'
 )
 
 __version__ = "0.0.1"

--- a/laviewset/resources.py
+++ b/laviewset/resources.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, NamedTuple
 from enum import Enum
 
 
@@ -133,13 +133,46 @@ class Resource:
         Side-effects:
             - will modify path if STRICT, SUBORDINATE
             combo are used.
+            - will raise TypeError for STRICT, EMPTY or
+            NON-STRICT, ~EMPTY
         """
         enforce = Rfc(self.enforce)
         res_type = Rfc(self.res_type)
 
         if enforce is Rfc.STRICT:
-            assert res_type is not Rfc.EMPTY, "RES TYPE IS NONE"
-            if res_type is Rfc.SUB:
-                self.path = self.path[:-1]
+            self._validate_strict(res_type)
         elif enforce is Rfc.NON_STRICT:
-            assert res_type is Rfc.EMPTY, "RES TYPE IS NOT NONE"
+            self._validate_non_strict(res_type)
+
+    def _validate_strict(self, res_type):
+        """Validate a STRICT, `res_type` combo.
+
+        Side-effects:
+            - may modify path
+            - may raise TypeError
+        """
+        if res_type is Rfc.EMPTY:
+            raise TypeError("Must set resource type  STRICT.")
+        if res_type is Rfc.SUB:
+            self.path = self.path[:-1]
+
+    @staticmethod
+    def _validate_non_strict(res_type):
+        """Validate a NON-STRICT, `res_type` combo.
+
+        Side-effects:
+            - may raise TypeError
+        """
+        if res_type is not Rfc.EMPTY:
+            raise TypeError("Don't set a resource type when NON-STRICT.")
+
+
+class RfcInterface(NamedTuple):
+
+    strict = Rfc.STRICT
+    non_strict = Rfc.NON_STRICT
+    collection = Rfc.COL
+    subordinate = Rfc.SUB
+
+
+rfc = RfcInterface()

--- a/laviewset/resources.py
+++ b/laviewset/resources.py
@@ -98,7 +98,15 @@ class Resource:
         return self.path
 
     def extend(self, path, *, enforce=None) -> Resource:
-        """Extend an already existing resource."""
+        """Extend an already existing resource.
+
+        Enforcement can be overridden in call to extend by
+        passing `enforce`, otherwise self's `enforce` will be
+        used.
+        """
+        if enforce is None:
+            enforce = self.enforce
+
         extended = Resource(
             self.path + path,
             enforce=enforce,

--- a/laviewset/resources.py
+++ b/laviewset/resources.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Callable
+from enum import Enum
+
+
+def strict_build(p: str):
+    # Append leading slash to all in u
+    # then append the trailing slash to
+    # the result.
+    result = ''
+    u = [r for r in p.split('/') if r]
+    for path in u:
+        result += f'/{path}'
+    return result + '/'
+
+
+def non_strict_build(p):
+    # Append leading slash to all in u
+    # and then append them.
+    result = ''
+    u = [r for r in p.split('/') if r]
+    for path in u:
+        result += f'/{path}'
+    return result
+
+
+class Rfc(Enum):
+
+    STRICT = 'strict'
+    NON_STRICT = 'non_strict'
+    COL = 'collection'
+    SUB = 'subordinate'
+    EMPTY = 'empty'
+
+    @classmethod
+    def get_build(cls, rfc: Rfc) -> [Callable[[str], str]]:
+        if cls(rfc) is cls.STRICT:
+            return strict_build
+        elif cls(rfc) is cls.NON_STRICT:
+            return non_strict_build
+        else:
+            # We return an identity function so
+            # no type checking is required by caller.
+            return lambda p: p
+
+
+class ResourceError(ValueError):
+
+    ...
+
+
+class Resource:
+    """
+    A resource builder class.
+
+    The URI's `scheme` and `authority` will be handled
+    by aiohttp. The Resource class only cares about `path`,
+    `query`, and `fragment`s.
+    """
+    path: str
+    enforce: Rfc
+    res_type: Rfc
+
+    def __init__(self, path, *, enforce=None, res_type=None):
+        self.path = path
+        self.enforce = enforce if enforce is not None else Rfc.NON_STRICT
+        self.res_type = res_type if res_type is not None else Rfc.EMPTY
+        self.build_strategy = Rfc.get_build(self.enforce)
+
+    @classmethod
+    def create_base(cls, *, enforce=None) -> Resource:
+        base = cls('/', enforce=enforce)
+        base.build()
+        return base
+
+    def build(self) -> None:
+        """Build the resource."""
+        self.path = self.build_strategy(self.path)
+
+    def __add__(self, other) -> Resource:
+        """Add two resources together.
+
+        Policies go upstream, meaning `other`'s policies
+        are used in the Resource that is to be returned.
+
+        The caller should expect a built resource.
+        """
+        new_resource = Resource(
+            self.path + other.path,
+            enforce=other.enforce,
+            res_type=other.res_type
+        )
+        new_resource.build()
+        return new_resource
+
+    def __str__(self):
+        return self.path
+
+    def extend(self, path, *, enforce=None) -> Resource:
+        """Extend an already existing resource."""
+        extended = Resource(
+            self.path + path,
+            enforce=enforce,
+        )
+        extended.build()
+        return extended
+
+    def leaf(self, path, *, res_type=None):
+        """Extend an already existing resource into a leaf.
+
+        The leaf resource can no longer be extended or
+        added on to, and will act as the final actionable
+        endpoint for a given resource.
+        """
+        leaf = Resource(
+            self.path + path,
+            enforce=self.enforce,
+            res_type=res_type
+        )
+        leaf.build()
+        leaf._validate_leaf()
+        return leaf
+
+    def _validate_leaf(self) -> None:
+        """Validate the policy and resource type
+        of a leaf Resource.
+
+        For example, if a STRICT policy is used, check
+        to make sure a Resource Type is given and make the
+        necessary modification.
+
+        Side-effects:
+            - will modify path if STRICT, SUBORDINATE
+            combo are used.
+        """
+        enforce = Rfc(self.enforce)
+        res_type = Rfc(self.res_type)
+
+        if enforce is Rfc.STRICT:
+            assert res_type is not Rfc.EMPTY, "RES TYPE IS NONE"
+            if res_type is Rfc.SUB:
+                self.path = self.path[:-1]
+        elif enforce is Rfc.NON_STRICT:
+            assert res_type is Rfc.EMPTY, "RES TYPE IS NOT NONE"

--- a/laviewset/routes.py
+++ b/laviewset/routes.py
@@ -25,7 +25,7 @@ def _pop(d: Dict[str, Any], key: str) -> Optional[Any]:
         del d[key]
     else:
         val = None
-    return
+    return val
 
 
 class ViewAttrs(NamedTuple):
@@ -111,7 +111,13 @@ class Route:
         """Decorator method to wrap a callable (handler), in a "view".
         """
         res_type = _pop(kw, 'res_type')
-        path: Resource = self._path.leaf(path, res_type=res_type)
+        try:
+            path: Resource = self._path.leaf(path, res_type=res_type)
+        except TypeError as te:
+            raise RouteError(
+                'Incorrect resource type '
+                f'for route: {te}'
+            ) from None
 
         # Any kwargs that get through to here
         # will be considered kwargs for web.routedef.

--- a/laviewset/views.py
+++ b/laviewset/views.py
@@ -233,7 +233,7 @@ class ViewSignatureError(TypeError):
 
 empty = object()
 _fake_app = cast(web.UrlDispatcher, object())
-_fake_route = Route('', _fake_app)
+_fake_route = Route.create_base(_fake_app)
 
 
 class _ViewSet:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,143 @@
+import pytest
+
+import mock
+
+from laviewset import rfc
+from laviewset.resources import (
+    non_strict_build,
+    strict_build,
+    Resource
+)
+
+
+def test_strict_build():
+    base = ''
+    listings = '/listings'
+    sessions = '/sessions'
+
+    assert strict_build(base) == '/'
+    assert strict_build(base + listings) == '/listings/'
+    assert (
+            strict_build(base + listings + sessions)
+            == '/listings/sessions/'
+    )
+
+
+def test_non_strict_build():
+    base = ''
+    listings = '/listings'
+    sessions = '/sessions'
+
+    assert non_strict_build(base) == ''
+    assert non_strict_build(base + listings) == '/listings'
+    assert (
+        non_strict_build(base + listings + sessions)
+        == '/listings/sessions'
+    )
+
+
+def test_create_base():
+    base_0 = Resource.create_base()  # default
+    base_1 = Resource.create_base(enforce=rfc.strict)
+
+    assert base_0.path == ''
+    assert base_0.enforce == rfc.non_strict
+
+    assert base_1.path == '/'
+    assert base_1.enforce == rfc.strict
+
+
+@mock.patch('laviewset.resources.non_strict_build')
+@mock.patch('laviewset.resources.strict_build')
+def test_build(mock_strict_build, mock_non_strict_build):
+    url = 'listings/sessions'
+    # Build occurs with main api interaction
+    # such as: create_base, extend, and leaf.
+    # Since we are just testing build, we directly
+    # init a Resource.
+    r_0 = Resource(path=url)    # default enforcement
+    r_1 = Resource(path=url, enforce=rfc.strict)
+
+    r_0.build()
+    mock_non_strict_build.assert_called_once_with(url)
+
+    r_1.build()
+    mock_strict_build.assert_called_once_with(url)
+
+
+# When testing for enforcement and builds on extensions,
+# leaves, and even bases, it suffices to assert the
+# correct enforcement type as well as a call to `Resource.build`.
+# In fact this may be preferable to directly testing the resulting
+# path.
+def test_extend_strict():
+    r_strict = Resource.create_base(enforce=rfc.strict)
+
+    with mock.patch.object(Resource, 'build') as mb_strict:
+        # No need to override enforcement since enforcement
+        # for extension is same as parent, i.e. strict.
+        extended_strict = r_strict.extend('listings')
+    mb_strict.assert_called_once_with()
+    assert extended_strict.enforce == rfc.strict
+
+    with mock.patch.object(Resource, 'build') as mb_non_strict:
+        # Here, we **do** need to override enforcement since
+        # extension's enforcement is different from parent.
+        extended_non_strict = r_strict.extend(
+            'sessions', enforce=rfc.non_strict
+        )
+    mb_non_strict.assert_called_once_with()
+    assert extended_non_strict.enforce == rfc.non_strict
+
+
+def test_extend_non_strict():
+    r_non_strict = Resource.create_base()
+
+    extended_non_strict = r_non_strict.extend('listings')
+    assert extended_non_strict.path == '/listings'
+    assert extended_non_strict.enforce == rfc.non_strict
+
+    extended_strict = r_non_strict.extend('sessions', enforce=rfc.strict)
+    assert extended_strict.path == '/sessions/'
+    assert extended_strict.enforce == rfc.strict
+
+
+@pytest.fixture
+def strict_extension():
+    r = Resource.create_base()
+    return r.extend('listings', enforce=rfc.strict)
+
+
+@pytest.fixture
+def non_strict_extension():
+    r = Resource.create_base()
+    return r.extend('listings')
+
+
+def test_leaf_strict_success(strict_extension):
+    col = strict_extension.leaf('/sessions', res_type=rfc.collection)
+    assert col.path == '/listings/sessions/'
+
+    sub = strict_extension.leaf('pk', res_type=rfc.subordinate)
+    assert sub.path == '/listings/pk'
+
+
+def test_leaf_strict_fail(strict_extension):
+    with pytest.raises(TypeError):
+        strict_extension.leaf('/sessions')
+
+
+def test_leaf_non_strict_success(non_strict_extension):
+    leaf_0 = non_strict_extension.leaf('/sessions')
+    assert leaf_0.path == '/listings/sessions'
+
+    leaf_1 = non_strict_extension.leaf('/pk')
+    assert leaf_1.path == '/listings/pk'
+
+
+def test_leaf_non_strict_fail(non_strict_extension):
+    with pytest.raises(TypeError):
+        non_strict_extension.leaf('sessions', res_type=rfc.collection)
+
+
+

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from typing import cast
 
 import pytest
+import mock
 from aiohttp import web
 
-from laviewset import routes
+from laviewset import routes, rfc
+from laviewset.resources import Rfc
 
 
 _PATH = '/'
@@ -94,3 +96,72 @@ def test_wrapping(base_router):
     assert view_attrs.path == test_route.path + ''
     assert view_attrs.method == _METHOD
     assert view_attrs.routedef_kwargs == _ROUTEDEF_KWARGS
+
+
+@pytest.fixture
+def strict_route():
+    return routes.Route.create_base(
+        _fake_router, enforce=rfc.strict)
+
+
+@pytest.fixture
+def non_strict_route():
+    return routes.Route.create_base(
+        _fake_router, enforce=rfc.non_strict)
+
+
+@mock.patch('laviewset.routes.ViewAttrs')
+def test_enforce_view(mocked_view_attrs, strict_route, view):
+    # Our use of rfc.collection is somewhat arbitrary, but also
+    # let's us see that the enforcement gets to the view.
+    col_resource = strict_route('/listings', 'GET', res_type=rfc.collection)
+    _ = col_resource(view)
+    mocked_view_attrs.assert_called_once_with(
+        '/listings/', 'GET', {}
+    )
+
+
+def test_strict_view_subordinate(strict_route, view):
+    sub_resource = strict_route('pk', 'GET', res_type=rfc.subordinate)
+    sub_view = sub_resource(view)
+    sub_view_attrs = routes.get_view_attrs(sub_view)
+    assert sub_view_attrs.path == '/pk'
+
+
+def test_strict_res_type_fail(strict_route):
+    """Test the failing of a strictly enforced view.
+    """
+    with pytest.raises(routes.RouteError):
+        strict_route('/listings', 'GET')  # enforce not set
+
+
+def test_non_strict_res_type_fail(non_strict_route):
+    with pytest.raises(routes.RouteError):
+        non_strict_route(
+            '/listings', 'GET',
+            res_type=rfc.strict     # res_type should not be set with
+        )                           # NON-STRICT
+
+
+def test_enforce_extension(strict_route, non_strict_route):
+    # Strict extensions
+    s_extended_strict = strict_route.extend('listings', enforce=rfc.strict)
+    s_extended_non_strict = strict_route.extend(
+        'listings', enforce=rfc.non_strict)
+
+    assert Rfc(s_extended_strict._path.enforce) is Rfc.STRICT
+    assert Rfc(s_extended_non_strict._path.enforce) is Rfc.NON_STRICT
+
+    # Non-strict extensions
+    ns_s_extended_strict = non_strict_route.extend(
+        'listings', enforce=rfc.strict)
+    ns_extended_non_strict = non_strict_route.extend(
+        'listings', enforce=rfc.non_strict)
+
+    assert Rfc(ns_s_extended_strict._path.enforce) is Rfc.STRICT
+    assert Rfc(ns_extended_non_strict._path.enforce) is Rfc.NON_STRICT
+
+
+def test_enforce_create_base(strict_route, non_strict_route):
+    assert Rfc(strict_route._path.enforce) is Rfc.STRICT
+    assert Rfc(non_strict_route._path.enforce) is Rfc.NON_STRICT

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -56,25 +56,6 @@ def test_get_view_attrs(view_with_attrs, not_view):
         routes.get_view_attrs(not_view)
 
 
-def test_route_add_success():
-    r1 = routes.Route.create_base(_fake_router)
-    r2 = routes.Route('/listings', _fake_router)
-    r3 = r1 + r2
-    assert r3.path == '/listings'
-
-    r1_v = routes.Route('/listings', _fake_router)
-    r2_v = routes.Route('/videos', _fake_router)
-    r3_v = r1_v + r2_v
-    assert r3_v.path == '/listings/videos'
-
-
-def test_route_add_fail():
-    r1 = routes.Route('/', _fake_router)
-    r2 = routes.Route('/listings', cast(web.UrlDispatcher, None))
-    with pytest.raises(routes.RouteError):
-        r1 + r2
-
-
 def test_create_base(base_router):
     assert base_router.is_base
     assert base_router.name == _ROUTE_NAME
@@ -86,7 +67,8 @@ def test_extend(base_router):
     r_0 = base_router.extend('/listings')
     assert r_0 != base_router
     assert r_0.path == '/listings'
-    assert r_0.name == _ROUTE_NAME
+    # Default name
+    assert r_0.name == f'Extension of Route: {base_router.name}'
     assert r_0.router is _fake_router
 
     r_1 = base_router.extend('listings')


### PR DESCRIPTION
This pull request attempts to do the following:

1_ Separate logic for handling resources and paths, away from `laviewset.routes` and into a separate module: `laviewset.resources`.

2_ Allow enforcement of "strict" RFC guides for Http schemes. Which is the smartest-sounding way I know to say "enforce trailing slashes", as mentioned in [this article](https://cdivilly.wordpress.com/2014/03/11/why-trailing-slashes-on-uris-are-important/), and with the help of [RFC #3986](https://tools.ietf.org/html/rfc3986#page-4).


> **Notes**


`1_` is pretty explanatory, but `2_` requires some more mention:

We attempt to allow the enforcement of trailing slashes through the identifiers `rfc.strict` and `rfc.non_strict`, which are allowed to be inputted in two API entries: when creating a base route (i.e. `Route.create_base()`), and when extending a route (i.e. `Route.extend()`).

By applying `rfc.non_strict`, there will be no distinction between a "collection" resource or a "subordinate" resource. What this means practically, is that URI's will not end in a trailing slash. Consider the following code below:

```
from aiohttp.web import Application
from laviewset import Route, ViewSet

app = Application()
base_route = Route.create_base(app.router)

class SomeViewSet(ViewSet):

    route = base_route.extend('/listings')

    @route('/', HttpMethods.GET)
    async def s(self, request): ...

    @route(r'/{pk:int}', HttpMethods.GET)
    async def p(self, request, *, pk): ...

```

In the above code snippet, the handler `s` will only get triggered with a `GET` request to the path `/listings`, and `p` with a `GET` at `/listings/{some_integer_id}`. Note the lack of a trailing slash for both. Also note how there is no change in how the user will interact with the API in any previous version. 

When `rfc.strict` is used as an enforcement, some changes do occur. A trailing slash will be appended to a URI **if** that resource is of type `rfc.collection`, which denotes a collection. Otherwise, the resource is a subordinate resource (and will need to be tagged as such - i.e. `rfc.subordinate`), which will result in a URI without a leading slash. Consider the code below:

```
from aiohttp.web import Application
from laviewset import Route, ViewSet, rfc

...

class SomeViewSet(ViewSet):

    route = base_route.extend('/listings', enforce=rfc.strict)

    @route('/', HttpMethods.GET, res_type=rfc.collection)
    async def s(self, request): ...

    @route(r'/{pk:int}', HttpMethods.GET, res_type=rfc.subordinate)
    async def p(self, request, *, pk): ...

```

Now, the handler `s` will only be triggered with a `GET` at `/listings/` but `p` will be accessible from a `GET` at `/listings/{some_integer_id}`. Note the trailing slash for `s` but none for `p`. 

It is important to note a few more things: 

* If `strict` is used, a `res_type` **must** be provided by the user in the `@route` decorator. Otherwise a `RouteError`will be raised from a `TypeError` that occurs from `laviewset.Resource`.

* If `non_strict` is used, no `res_type` should be provided - a `RouteError` will be raised otherwise.

* At anytime during the API entries (i.e. `Route.create_base()`, `Route.extend()`), the enforcement policy can be overridden.

* If the enforcement policy is not overridden for an extension (i.e. `Route.extend()`), then the parent `Resource`'s enforcement will be used.

* The default value for the API entries is `rfc.non_strict`, thus not affecting how the user interfaces with the API in any previous version.

Finally, before pulling into master and making it a part of the official API, there exists considerations for changing the entry point of enforcement to use `True` and `False` instead of `rfc.strict` or `rfc.non_strict`. The pro for this consideration is that it makes sense, because the options are binary. The con for this consideration is that `enforce=rfc.strict` and `enforce=rfc.non_strict` are more explicit than `enforce=True` and `enforce=False`, which could read better.

